### PR TITLE
State only address

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -195,7 +195,7 @@ class Parser
             $citySection = trim($addressArray[count($addressArray) - 1]);
         } else {
             array_splice($addressArray, -1);
-            $citySection = trim($addressArray[count($addressArray) - 1]);
+            $citySection = count($addressArray) > 0 ? trim($addressArray[count($addressArray) - 1]) : '';
         }
         foreach ($store->getCities($parsed['state']) as $city) {
             if (preg_match('/ (City|Township)$/i', $citySection) !== 0) {


### PR DESCRIPTION
Fix for an "address" that is only a state name.

It is simply checking for array length before referencing a count - 1 index value.

This is a fix for issue #8 